### PR TITLE
Providing falsy `styles` argument for reseting the styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 module.exports = function setStyles(elm, styles){
+  styles = styles || {}
   var lines = []
   for (var prop in styles){
     lines.push(deCamelCase(prop) + ': ' + String(styles[prop]) + ';')


### PR DESCRIPTION
With this change, `setStyles(elm)` or `setStyles(elm, null)` will remove all current style rules.
